### PR TITLE
[FreeBSD] Add support for the FreeBSD platform

### DIFF
--- a/tasks/FreeBSD.yml
+++ b/tasks/FreeBSD.yml
@@ -1,0 +1,21 @@
+# Copyright 2016 Yanis Guenane <yguenane@redhat.com>
+# Author: Yanis Guenane <yguenane@redhat.com>
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Install required dependencies
+  package: name={{ item }}
+  with_items:
+    - py27-pip
+    - py27-setuptools_scm

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,24 @@
+# Copyright 2016 Yanis Guenane <yguenane@redhat.com>
+# Author: Yanis Guenane <yguenane@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Install required dependencies
+  yum: name={{ item }}
+  with_items:
+    - gcc
+    - python-devel
+    - libffi-devel
+    - openssl-devel
+    - python-pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,6 @@
 ---
-# NOTE(spredzy): To remove once lecm is packaged
 - name: Install required dependencies
-  yum: name={{ item }}
-  with_items:
-    - gcc
-    - python-devel
-    - libffi-devel
-    - openssl-devel
-    - python-pip
+  include: '{{ ansible_os_family }}.yml'
 
 - name: Install lecm from Pip
   pip: name=lecm


### PR DESCRIPTION
This role was developed while testing on a CentOS 7 server.
This commit adds support for the FreeBSD platform. The commit
externalize the list of package dependencies of a $PLATFORM.yml file.
