### PR TITLE
assign a default value to lecm_crons

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,5 @@ lecm_globals: {}
 # lecm certificates settings
 lecm_certificates: {}
 
+# configuration for the cron module
+lecm_crons: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,5 +43,4 @@
         month={{ item.value.month | default('*') }}
         job={{ item.value.job | default('lecm --renew') }}
         state={{ item.value.state | default('present') }}
-  when: '{{ lecm_crons is defined }}'
   with_dict: '{{ lecm_crons }}'


### PR DESCRIPTION
Ensure lecm_crons is always initialized to avoid error like this one (ansible 2.1.2):

  TASK [Spredzy.lecm : Configure the lecm crons (if desired)]
  ********************
  [DEPRECATION WARNING]: Skipping task due to undefined Error, in the
  future this
   will be a fatal error.: 'lecm_crons' is undefined.