### PR TITLE
Fix yaml syntax for python-pip package

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -28,13 +28,13 @@
 
   - name: Install python-pip
     package:
-      name: {% if ansible_distribution_major_version == 7 %}python{% else %}python3{% endif %}-pip
+      name: "{% if ansible_distribution_major_version == 7 %}python{% else %}python3{% endif %}-pip"
 
   - name: Install acme-tiny
     package:
       name: acme-tiny
     when: ansible_distribution_major_version == 8
-      
+
   - name: Install lecm
     pip:
       name: lecm


### PR DESCRIPTION
There were some missing double quotes around the package name containing
inline Jinja templating.